### PR TITLE
Append all arguments to --complete

### DIFF
--- a/completions/sub.bash
+++ b/completions/sub.bash
@@ -5,8 +5,8 @@ _sub() {
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "$(sub commands)" -- "$word") )
   else
-    local command="${COMP_WORDS[1]}"
-    local completions="$(sub completions "$command")"
+    local command="${COMP_WORDS[@]:1:${#COMP_WORDS[@]}-2}"
+    local completions="$(sub completions $command)"
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
   fi
 }


### PR DESCRIPTION
Fixes #7
(if using bash)

When bash-completion is invoked, all arguments are now forwarded to the command, e.g.

sub command arg1 arg2 <tab>

now triggers:

sub --complete command arg1 arg2

instead of just:

sub --complete command